### PR TITLE
Update perforce from 19.1-1845410 to 19.1-1865205

### DIFF
--- a/Casks/perforce.rb
+++ b/Casks/perforce.rb
@@ -1,6 +1,6 @@
 cask 'perforce' do
-  version '19.1-1813586'
-  sha256 '3cd4c1f0e4561f11d435cdca40f32218370e9d8e37ad5edbcdcddea4ba3123df'
+  version '19.1-1865205'
+  sha256 '71ad48f8af851978016d52132dff28638c7d8dced2479ea0a1a04e73e74ac2c5'
 
   url "https://cdist2.perforce.com/perforce/r#{version.major_minor}/bin.macosx1010x86_64/helix-core-server.tgz"
   name 'Perforce Helix Versioning Engine'


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

I don't have a macOS machine available to test all these. The problem was detected during a PR build: https://dev.azure.com/gitgitgadget/git/_build/results?buildId=18491&view=logs. I updated the values following https://github.com/Homebrew/homebrew-cask/pull/68754/files as an example, using the SHA-256 value from the failed build and the version number from https://www.perforce.com/downloads/helix-core-p4d.